### PR TITLE
error in carousel function

### DIFF
--- a/nativescript-slides.ts
+++ b/nativescript-slides.ts
@@ -152,7 +152,11 @@ export class SlideContainer extends AbsoluteLayout {
 	private carousel(isenabled: boolean, time: number) {
 		if (isenabled) {
 			this.timer_reference = setInterval(() => {
-				this.nextSlide();
+				if(typeof this.currentPanel.right !== "undefined") {
+					this.nextSlide();
+				}else {
+					clearTimeout(this.timer_reference);
+				}
 			}, time);
 		} else {
 			clearTimeout(this.timer_reference);


### PR DESCRIPTION
If loop is not true but interval is set then after reaching the last slide the app crashes because in last slide there is no right slide but the carousel function calls the rightslide function since right slide at that point is undefined.