### PR TITLE
When the slide container does not have page indicators, changed events

### DIFF
--- a/nativescript-slides.ts
+++ b/nativescript-slides.ts
@@ -374,7 +374,9 @@ export class SlideContainer extends AbsoluteLayout {
 		if (this.disablePan === false) {
 			this.applySwipe(this.pageWidth);
 		}
-		this.setActivePageIndicator(this.currentPanel.index);
+		if (this.pageIndicators) {
+			this.setActivePageIndicator(this.currentPanel.index);
+		}
 		this.rebindSlideShow();
 	}
 


### PR DESCRIPTION
do not fire while swiping through the slides.

This is because this._footer is referenced by setActivePageIndicator,
which is undefined in the case where we have no page indicators.

Fix is to only call setActivePageIndicator when we have page indicators
enabled.