### PR TITLE
Fix indicators visibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,6 +195,8 @@ export function onSlideContainerLoaded(args) {
 
 [Andrew Lo](https://github.com/andrewlo)
 
+[Raúl Uranga](https://github.com/rauluranga/)
+
 And thanks to [Nathan Walker](https://github.com/NathanWalker) for setting up the {N} plugin seed that was used to help get this plugin up and running. More info can be found about it here:
 https://github.com/NathanWalker/nativescript-plugin-seed
 

--- a/nativescript-slides.ts
+++ b/nativescript-slides.ts
@@ -224,13 +224,13 @@ export class SlideContainer extends AbsoluteLayout {
 							}
 							
 							if (this.pageIndicators) {
-                                AbsoluteLayout.setTop(this._footer, 0);
-                                var pageIndicatorsLeftOffset = this.pageWidth / 4;
-                                AbsoluteLayout.setLeft(this._footer, pageIndicatorsLeftOffset);
-                                this._footer.width = this.pageWidth / 2;
-                                this._footer.marginTop = this._pagerOffset;
-                            }
-                            
+								AbsoluteLayout.setTop(this._footer, 0);
+								var pageIndicatorsLeftOffset = this.pageWidth / 4;
+								AbsoluteLayout.setLeft(this._footer, pageIndicatorsLeftOffset);
+								this._footer.width = this.pageWidth / 2;
+								this._footer.marginTop = this._pagerOffset;
+							}
+							
 							this.positionPanels(this.currentPanel);
 						}, 0);
 					});

--- a/nativescript-slides.ts
+++ b/nativescript-slides.ts
@@ -222,10 +222,15 @@ export class SlideContainer extends AbsoluteLayout {
 							if (this.disablePan === false) {
 								this.applySwipe(this.pageWidth);
 							}
-							let topOffset = Platform.screen.mainScreen.heightDIPs - 105;
+							
 							if (this.pageIndicators) {
-								this._footer.marginTop = <any>'88%';
-							}
+                                AbsoluteLayout.setTop(this._footer, 0);
+                                var pageIndicatorsLeftOffset = this.pageWidth / 4;
+                                AbsoluteLayout.setLeft(this._footer, pageIndicatorsLeftOffset);
+                                this._footer.width = this.pageWidth / 2;
+                                this._footer.marginTop = this._pagerOffset;
+                            }
+                            
 							this.positionPanels(this.currentPanel);
 						}, 0);
 					});


### PR DESCRIPTION
Hi!
this patch resolves #83, resolves #84, it's also related with issue #43.

you need to update AbsoluteLayout positions for the footer in the orientationChange event, otherwise page indicators won't show up on device.

tested on a real devices (iPhone 6, iPhone 5s)
