### PR TITLE
Set slideWidth explicitly during pageLoad

### DIFF
--- a/demo/app/views/main-page.ts
+++ b/demo/app/views/main-page.ts
@@ -11,6 +11,9 @@ export function pageLoaded(args: observable.EventData) {
 	var page = <pages.Page>args.object;
 	page.actionBarHidden = true;
 	slideContainer = page.getViewById("slides");
+	
+	// Set dimenions during pageLoad -- doesn't seem to work if waiting 'til later in view lifecycle
+	slideContainer.slideWidth = Platform.screen.mainScreen.widthDIPs;
 }
 
 export function onNavHome() {


### PR DESCRIPTION
Ensures dimensions are set properly for slideContainer. In new 3.0 lifecycle, I think dimensions need to be set earlier?