### PR TITLE
Explicitly checking 'loop' to prevent misconfiguration evaluation

### DIFF
--- a/nativescript-slides.ts
+++ b/nativescript-slides.ts
@@ -550,7 +550,7 @@ export class SlideContainer extends AbsoluteLayout {
 				mapping.right = this._slideMap[index + 1];
 		});
 
-		if (this.loop) {
+		if (this.loop === true) {
 			this._slideMap[0].left = this._slideMap[this._slideMap.length - 1];
 			this._slideMap[this._slideMap.length - 1].right = this._slideMap[0];
 		}


### PR DESCRIPTION
Set evaluation of `loop` property to only enter conditional if value is explicitly `true`. This eliminates the scenario presented in issue #111.