### PR TITLE
Support disabling Pan at runtime

### DIFF
--- a/nativescript-slides.ts
+++ b/nativescript-slides.ts
@@ -105,7 +105,16 @@ export class SlideContainer extends AbsoluteLayout {
 	}
 
 	set disablePan(value: boolean) {
+		if (this._disablePan === value) { return; } // Value did not change
+
 		this._disablePan = value;
+		if (this._loaded && this.currentPanel.panel !== undefined) {
+			if (value === true) {
+				this.currentPanel.panel.off('pan');
+			} else if (value === false) {
+				this.applySwipe(this.pageWidth);	
+			}
+		}
 	}
 
 	get pageWidth() {


### PR DESCRIPTION
This change makes it possible to disable the "pan" behavior at runtime AFTER the slider has been loaded. Currently, the `disablePan` property is only checked during initial load. If it is changed after the Slider loads, it has no effect. With this change, setting `disablePan` to `true` at runtime will remove the `pan` event handler for the `currentPanel.panel`. If `disablePan` is set to `true`, the `applySwipe` method is called to re-init the `pan` gesture handler for the `currentPanel.panel`. This helps in cases where there are nested UI elements inside of a Slider trying to capture `pan` events. If `disablePan` is `false` in these cases, the `pan` events for nested UI elements can get swallowed by the Slider. Now a nested UI element can call `disablePan = false` during its own `pan` event, and then re-enable the Slider with `disablePan = true` when the `pan` event is complete.